### PR TITLE
Better problem definition in train

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ This repository is still in development: new functionality is being added and th
 | 3       | Add fidelity bounds for MPS |           #6 |
 | 4       | Add QAOA angles functions   |          #14 |
 | 5       | Switch to qaoa_ansatz       |          #16 |
+| 6       | Add problem class in train  |          #17 |
 
 ## IBM Public Repository Disclosure
 

--- a/qaoa_training_pipeline/train.py
+++ b/qaoa_training_pipeline/train.py
@@ -146,7 +146,7 @@ def train(args: Optional[List]):
     if class_str is not None:
         class_info = class_str.split(":")
         class_name = class_info[0].lower()
-        
+
         class_init_str = ""
         if len(class_info) > 1:
             class_init_str = class_info[1]

--- a/qaoa_training_pipeline/train.py
+++ b/qaoa_training_pipeline/train.py
@@ -153,8 +153,8 @@ def train(args: Optional[List]):
 
         if class_name not in PROBLEM_CLASSES:
             raise ValueError(
-                f"The problem class {class_name} is not supported. 
-                Valid problem classes are {PROBLEM_CLASSES.keys()}"
+                f"The problem class {class_name} is not supported. "
+                "Valid problem classes are {PROBLEM_CLASSES.keys()}"
             )
 
         problem_class = PROBLEM_CLASSES[class_name].from_str(class_init_str)

--- a/qaoa_training_pipeline/train.py
+++ b/qaoa_training_pipeline/train.py
@@ -34,6 +34,7 @@ from datetime import datetime
 from qaoa_training_pipeline.utils.data_utils import load_input, input_to_operator
 from qaoa_training_pipeline.evaluation import EVALUATORS
 from qaoa_training_pipeline.training import TRAINERS
+from qaoa_training_pipeline.utils.problem_classes import PROBLEM_CLASSES
 
 
 def get_script_args():
@@ -142,9 +143,9 @@ def train(args: Optional[List]):
 
     # Load the input.
     class_str = getattr(args, "problem_class", None)
-    if input_class is not None:
+    if class_str is not None:
         class_info = class_str.split(":")
-        class_name = class_info[0]
+        class_name = class_info[0].lower()
         
         class_init_str = ""
         if len(class_info) > 1:
@@ -226,6 +227,7 @@ def train(args: Optional[List]):
                 json.dump({k: v.data for k, v in all_results.items()}, fout, indent=4)
 
     all_results["args"] = vars(args)
+    all_results["cost_operator"] = input_problem.to_list()
     return all_results
 
 

--- a/qaoa_training_pipeline/train.py
+++ b/qaoa_training_pipeline/train.py
@@ -151,6 +151,12 @@ def train(args: Optional[List]):
         if len(class_info) > 1:
             class_init_str = class_info[1]
 
+        if class_name not in PROBLEM_CLASSES:
+            raise ValueError(
+                f"The problem class {class_name} is not supported. 
+                Valid problem classes are {PROBLEM_CLASSES.keys()}"
+            )
+
         problem_class = PROBLEM_CLASSES[class_name].from_str(class_init_str)
         input_problem = problem_class.cost_operator(load_input(args.input))
     else:

--- a/qaoa_training_pipeline/train.py
+++ b/qaoa_training_pipeline/train.py
@@ -49,11 +49,16 @@ def get_script_args():
         help="The path to the graph or hyper graph to train on.",
     )
 
+    description = "A string to create instances of known optimization problems with "
+    description += "the format `problem_class_name` or `problem_class_name:input_str`. "
+    description += "Here, problem_class_name is a key in PROBLEM_CLASSES and "
+    description += "input_str is a string to initialize the problem class if needed."
+
     parser.add_argument(
         "--problem_class",
         required=False,
         type=str,
-        help="A string to create instances of known optimization problems.",
+        help=description,
     )
 
     description = "A pre-factor that multiplies all the weights in the input. "

--- a/qaoa_training_pipeline/training/param_result.py
+++ b/qaoa_training_pipeline/training/param_result.py
@@ -47,7 +47,7 @@ class ParamResult:
             "system": platform.system(),
             "processor": platform.processor(),
             "platform": platform.platform(),
-            "qaoa_training_pipeline_version": 5,
+            "qaoa_training_pipeline_version": 6,
         }
 
         # Convert, e.g., np.float to float

--- a/qaoa_training_pipeline/utils/data_utils.py
+++ b/qaoa_training_pipeline/utils/data_utils.py
@@ -64,7 +64,7 @@ def input_to_operator(input_data: dict, pre_factor: float = 1.0) -> SparsePauliO
     # First, find the maximum number of variables.
     n_vars = 0
     for term in input_data["edge list"]:
-        n_vars = max([n_vars] + term["nodes"])
+        n_vars = max([n_vars] + list(term["nodes"]))
 
     for term in input_data["edge list"]:
         paulis = ["I"] * (n_vars + 1)

--- a/qaoa_training_pipeline/utils/problem_classes.py
+++ b/qaoa_training_pipeline/utils/problem_classes.py
@@ -23,7 +23,7 @@ class MaxCut:
     # pylint: disable=unused-argument
     @classmethod
     def from_str(cls, input_str: Optional[str] = "") -> "MaxCut":
-        """Create the class. Note that the input is not needed."""
+        """Create the class. Note that the input string is not used."""
         return cls()
 
     def cost_operator(self, input_data: dict):

--- a/qaoa_training_pipeline/utils/problem_classes.py
+++ b/qaoa_training_pipeline/utils/problem_classes.py
@@ -1,6 +1,6 @@
 #
 #
-# (C) Copyright IBM 2024.
+# (C) Copyright IBM 2025.
 #
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
@@ -13,16 +13,17 @@ from typing import Optional
 from qiskit_optimization.applications import StableSet
 from qiskit_optimization.converters import QuadraticProgramToQubo
 
-from qaoa_training_pipeline.utils.data_utils import load_input, input_to_operator
+from qaoa_training_pipeline.utils.data_utils import input_to_operator
 from qaoa_training_pipeline.utils.graph_utils import dict_to_graph
 
 
 class MaxCut:
     """Produce max-cut operators from input graphs."""
 
+    # pylint: disable=unused-argument
     @classmethod
     def from_str(cls, input_str: Optional[str] = "") -> "MaxCut":
-        """Create the class from a string."""
+        """Create the class. Note that the input is not needed."""
         return cls()
 
     def cost_operator(self, input_data: dict):
@@ -43,12 +44,21 @@ class MaxIndependentSet:
     DEFAULT_PENALTY = 2.0
 
     def __init__(self, penalty: Optional[float] = None):
-        """Create the maximum independent set class."""
+        """Create the maximum independent set class.
+        
+        Args:
+            penalty: The penalty to use for the cost operator. Defaults to 2.0.
+        """
         self._penalty = penalty or self.DEFAULT_PENALTY
 
     @classmethod
     def from_str(cls, input_str: Optional[str] = "") -> "MaxIndependentSet":
-        """Create the class from a string."""
+        """Create the class from a string.
+        
+        Args:
+            input_str: If given, it will be converted to a float representing the
+                penalty in from of the edge constraints.
+        """
         try:
             penalty = float(input_str)
         except ValueError:

--- a/qaoa_training_pipeline/utils/problem_classes.py
+++ b/qaoa_training_pipeline/utils/problem_classes.py
@@ -6,45 +6,71 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Functions to create instances of known problem classes from input."""
+"""Functions to create cost operators of known problem classes from input."""
+
+from typing import Optional
+
+from qiskit_optimization.applications import StableSet
+from qiskit_optimization.converters import QuadraticProgramToQubo
 
 from qaoa_training_pipeline.utils.data_utils import load_input, input_to_operator
+from qaoa_training_pipeline.utils.graph_utils import dict_to_graph
 
 
 class MaxCut:
     """Produce max-cut operators from input graphs."""
 
     @classmethod
-    def from_str(cls, input_str: str) -> "MaxCut":
+    def from_str(cls, input_str: Optional[str] = "") -> "MaxCut":
         """Create the class from a string."""
         return cls()
 
-    def cost_operator(self, input):
+    def cost_operator(self, input_data: dict):
         """Create the cost operator from the input.
         
         The (weighted) edges of the graph are converted to ZZ with a prefoactor of -0.5.
+
+        Args:
+            input: A dict specifying a graph where the keys are tuples of ints representing 
+                edges or hyper-edge and the values are the weights.
         """
-        return input_to_operator(input, pre_factor=-0.5)
+        return input_to_operator(input_data, pre_factor=-0.5)
 
 
 class MaxIndependentSet:
     """Produce max independent set operators from input graphs."""
 
-    def __init__(self, penalty: float = 2.0):
+    DEFAULT_PENALTY = 2.0
+
+    def __init__(self, penalty: Optional[float] = None):
         """Create the maximum independent set class."""
-        self._penalty = penalty
+        self._penalty = penalty or self.DEFAULT_PENALTY
 
     @classmethod
     def from_str(cls, input_str: Optional[str] = "") -> "MaxIndependentSet":
         """Create the class from a string."""
-        penalty = float(input_str) 
-        return cls()
+        try:
+            penalty = float(input_str)
+        except ValueError:
+            penalty = cls.DEFAULT_PENALTY
 
-    def cost_operator(self, input):
-        """Create the cost operator from the input."""
+        return cls(penalty)
+
+    def cost_operator(self, input_data: dict):
+        """Create the cost operator from the input graph given as dict.
+        
+        Args:
+            input_data: A dict specifying a graph where the keys are tuples of ints representing 
+                edges or hyper-edge and the values are the weights.
+        """
+        graph = dict_to_graph(input_data)
+        qp_ = StableSet(graph).to_quadratic_program()
+        cost_op, _ = QuadraticProgramToQubo(penalty=self._penalty).convert(qp_).to_ising()
+
+        return cost_op
 
 
 PROBLEM_CLASSES = {
-    "MaxCut": MaxCut,
-    "MaxIndependentSet": MaxIndependentSet,
+    "maxcut": MaxCut,
+    "mis": MaxIndependentSet,
 }

--- a/qaoa_training_pipeline/utils/problem_classes.py
+++ b/qaoa_training_pipeline/utils/problem_classes.py
@@ -28,11 +28,11 @@ class MaxCut:
 
     def cost_operator(self, input_data: dict):
         """Create the cost operator from the input.
-        
+
         The (weighted) edges of the graph are converted to ZZ with a prefoactor of -0.5.
 
         Args:
-            input: A dict specifying a graph where the keys are tuples of ints representing 
+            input: A dict specifying a graph where the keys are tuples of ints representing
                 edges or hyper-edge and the values are the weights.
         """
         return input_to_operator(input_data, pre_factor=-0.5)
@@ -45,7 +45,7 @@ class MaxIndependentSet:
 
     def __init__(self, penalty: Optional[float] = None):
         """Create the maximum independent set class.
-        
+
         Args:
             penalty: The penalty to use for the cost operator. Defaults to 2.0.
         """
@@ -54,7 +54,7 @@ class MaxIndependentSet:
     @classmethod
     def from_str(cls, input_str: Optional[str] = "") -> "MaxIndependentSet":
         """Create the class from a string.
-        
+
         Args:
             input_str: If given, it will be converted to a float representing the
                 penalty in from of the edge constraints.
@@ -68,9 +68,9 @@ class MaxIndependentSet:
 
     def cost_operator(self, input_data: dict):
         """Create the cost operator from the input graph given as dict.
-        
+
         Args:
-            input_data: A dict specifying a graph where the keys are tuples of ints representing 
+            input_data: A dict specifying a graph where the keys are tuples of ints representing
                 edges or hyper-edge and the values are the weights.
         """
         graph = dict_to_graph(input_data)

--- a/qaoa_training_pipeline/utils/problem_classes.py
+++ b/qaoa_training_pipeline/utils/problem_classes.py
@@ -1,0 +1,50 @@
+#
+#
+# (C) Copyright IBM 2024.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Functions to create instances of known problem classes from input."""
+
+from qaoa_training_pipeline.utils.data_utils import load_input, input_to_operator
+
+
+class MaxCut:
+    """Produce max-cut operators from input graphs."""
+
+    @classmethod
+    def from_str(cls, input_str: str) -> "MaxCut":
+        """Create the class from a string."""
+        return cls()
+
+    def cost_operator(self, input):
+        """Create the cost operator from the input.
+        
+        The (weighted) edges of the graph are converted to ZZ with a prefoactor of -0.5.
+        """
+        return input_to_operator(input, pre_factor=-0.5)
+
+
+class MaxIndependentSet:
+    """Produce max independent set operators from input graphs."""
+
+    def __init__(self, penalty: float = 2.0):
+        """Create the maximum independent set class."""
+        self._penalty = penalty
+
+    @classmethod
+    def from_str(cls, input_str: Optional[str] = "") -> "MaxIndependentSet":
+        """Create the class from a string."""
+        penalty = float(input_str) 
+        return cls()
+
+    def cost_operator(self, input):
+        """Create the cost operator from the input."""
+
+
+PROBLEM_CLASSES = {
+    "MaxCut": MaxCut,
+    "MaxIndependentSet": MaxIndependentSet,
+}

--- a/test/data/test_graph.json
+++ b/test/data/test_graph.json
@@ -1,0 +1,19 @@
+{
+    "edge list": [
+        {
+            "nodes": [
+                0,
+                1
+            ],
+            "weight": 1
+        },
+        {
+            "nodes": [
+                0,
+                2
+            ],
+            "weight": 1
+        }
+    ],
+    "Description": "A small test graph."
+}

--- a/test/training/test_train.py
+++ b/test/training/test_train.py
@@ -17,6 +17,8 @@ import sys
 from unittest.mock import patch
 from ddt import ddt, data
 
+from qiskit.quantum_info import SparsePauliOp
+
 from qaoa_training_pipeline.train import train, get_script_args
 
 
@@ -56,6 +58,41 @@ class TestTrain(TrainingPipelineTestCase):
                 result["args"]["train_kwargs0"],
                 "num_points:10:parameter_ranges:3/6/3/6",
             )
+
+    @data("maxcut", "mis:3", "mis")
+    def test_problem_classes(self, problem_str: str):
+        """Test that we can call train.py."""
+
+        test_args = [
+            "prog",
+            "--input",
+            "test/data/test_graph.json",
+            "--config",
+            "data/methods/train_method_0.json",
+            "--train_kwargs0",
+            "num_points:2:parameter_ranges:3/6/3/6",
+            "--problem_class",
+            problem_str,
+        ]
+
+        op1 = [("IZZ", -0.5), ("ZIZ", -0.5)]
+        op2 = [("IIZ", -0.5), ("IZZ", 0.5), ("ZIZ", 0.5)]
+        op3 = [("IIZ", -1.0), ("IZI", -0.25), ("ZII", -0.25), ("IZZ", 0.75), ("ZIZ", 0.75)]
+
+        expected = {
+            "maxcut": SparsePauliOp.from_list(op1),
+            "mis": SparsePauliOp.from_list(op2),
+            "mis:3": SparsePauliOp.from_list(op3),
+        }
+
+        with patch.object(sys, "argv", test_args):
+            args, _ = get_script_args()
+            result = train(args)
+
+            cost_op = SparsePauliOp.from_list(result["cost_operator"])
+
+            self.assertEqual(result["args"]["problem_class"], problem_str)
+            self.assertEqual(cost_op, expected[problem_str])
 
     def test_call_train_schmidt(self):
         """Test that the Schmidt values are returned with an MPS-based training."""

--- a/test/training/test_train.py
+++ b/test/training/test_train.py
@@ -94,6 +94,29 @@ class TestTrain(TrainingPipelineTestCase):
             self.assertEqual(result["args"]["problem_class"], problem_str)
             self.assertEqual(cost_op, expected[problem_str])
 
+    def test_validate_args(self):
+        """Test that the arguments are validated correctly."""
+
+        test_args = [
+            "prog",
+            "--input",
+            "data/problems/example_graph.json",
+            "--config",
+            "data/methods/train_method_4.json",
+            "--problem_class",
+            "maxcut",
+            "--pre_factor",
+            "2.0",
+            False,
+        ]
+
+        with patch.object(sys, "argv", test_args):
+            args, _ = get_script_args()
+
+            with self.assertRaises(ValueError) as error:
+                train(args)
+                self.assertTrue("cannott be used together" in error.exception.args[0])
+
     def test_call_train_schmidt(self):
         """Test that the Schmidt values are returned with an MPS-based training."""
 

--- a/test/utils/test_problem_classes.py
+++ b/test/utils/test_problem_classes.py
@@ -30,7 +30,7 @@ class TestProblemClasses(TrainingPipelineTestCase):
             "edge list": [{"nodes": (0, 1), "weight": 1}, {"nodes": (0, 2), "weight": 1}]
         }
 
-        op1 = [[("IZZ", -0.5), ("ZIZ", -0.5)]]
+        op1 = [("IZZ", -0.5), ("ZIZ", -0.5)]
         op2 = [("IIZ", -0.5), ("IZZ", 0.5), ("ZIZ", 0.5)]
         op3 = [("IIZ", -1.0), ("IZI", -0.25), ("ZII", -0.25), ("IZZ", 0.75), ("ZIZ", 0.75)]
 

--- a/test/utils/test_problem_classes.py
+++ b/test/utils/test_problem_classes.py
@@ -1,0 +1,52 @@
+#
+#
+# (C) Copyright IBM 2024.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests of problem classes."""
+
+from test import TrainingPipelineTestCase
+
+from ddt import ddt, data, unpack
+
+from qiskit.quantum_info import SparsePauliOp
+
+from qaoa_training_pipeline.utils.problem_classes import PROBLEM_CLASSES
+
+
+@ddt
+class TestProblemClasses(TrainingPipelineTestCase):
+    """Test the problem classes."""
+
+    @unpack
+    @data(("maxcut", None), ("mis", None), ("mis", [3.0]))
+    def test_cost_operator(self, class_name: str, init_args):
+        """Test that the problem classes give the right cost operators."""
+
+        input_graph = {
+            "edge list": [{"nodes": (0, 1), "weight": 1}, {"nodes": (0, 2), "weight": 1}]
+        }
+
+        op1 = [[("IZZ", -0.5), ("ZIZ", -0.5)]]
+        op2 = [("IIZ", -0.5), ("IZZ", 0.5), ("ZIZ", 0.5)]
+        op3 = [("IIZ", -1.0), ("IZI", -0.25), ("ZII", -0.25), ("IZZ", 0.75), ("ZIZ", 0.75)]
+
+        expected = {
+            ("maxcut", None): SparsePauliOp.from_list(op1),
+            ("mis", None): SparsePauliOp.from_list(op2),
+            ("mis", 3.0): SparsePauliOp.from_list(op3),
+        }
+
+        if init_args is not None:
+            problem_class = PROBLEM_CLASSES[class_name](*init_args)
+            key = init_args[0]
+        else:
+            problem_class = PROBLEM_CLASSES[class_name]()
+            key = None
+
+        cost_op = problem_class.cost_operator(input_graph)
+
+        self.assertEqual(cost_op, expected[(class_name, key)])


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.

-->

### Summary

Many problems are defined on the same type of input, e.g., graph problems.

### Details and comments

In this PR we make the `train.py` method more flexible in terms of creating the cost operator to solve. This is done by adding an extra argument to the command line input. This argument allows us to specify the class of problem to create based on the input (which is typically a graph). In this PR we add support for Maxcut and Maximum Independent Set. More class can be added on an as need basis.

### Version updated

Please increment the `qaoa_training_pipeline_version` variable and extend the main README.md. 

- [x] Done
