### PR TITLE
Implementation of the recursive transition states trainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ This repository is still in development: new functionality is being added and th
 | 7       | Add problem class in train  |          #17 |
 | 8       | Improve train tests         |          #22 |
 | 9       | Add SAT map pre-processing  |          #19 |
+|10       | Add recursive transition states trainer|#20|
 
 ## IBM Public Repository Disclosure
 

--- a/data/methods/train_method_7.json
+++ b/data/methods/train_method_7.json
@@ -3,11 +3,8 @@
         {
             "trainer": "DepthOneScanTrainer",
             "trainer_init": {
-                "evaluator": "MPSEvaluator",
-                "evaluator_init": {
-                    "use_vidal_form": "True",
-                    "use_swap_strategy": "True"
-                }
+                "evaluator": "EfficientDepthOneEvaluator",
+                "evaluator_init": {}
             },
             "train_kwargs": {
                 "parameter_ranges": [
@@ -51,4 +48,5 @@
         }
     ],
     "description": "Recursive Transition States Trainer (p=3)"
+
 }

--- a/data/methods/train_method_7.json
+++ b/data/methods/train_method_7.json
@@ -1,0 +1,54 @@
+{
+    "trainer_chain": [
+        {
+            "trainer": "DepthOneScanTrainer",
+            "trainer_init": {
+                "evaluator": "MPSEvaluator",
+                "evaluator_init": {
+                    "use_vidal_form": "True",
+                    "use_swap_strategy": "True"
+                }
+            },
+            "train_kwargs": {
+                "parameter_ranges": [
+                    [
+                        0,
+                        3.1456
+                    ],
+                    [
+                        0,
+                        3.1456
+                    ]
+                ],
+                "num_points": 15
+            }
+        },
+        {
+            "trainer": "RecursiveTransitionStates",
+            "trainer_init": {
+                "trainer": "ScipyTrainer",
+                "trainer_init": {
+                    "evaluator": "MPSEvaluator",
+                    "evaluator_init": {
+                        "use_vidal_form": "True",
+                        "use_swap_strategy": "True"
+                    },
+                    "minimize_args": {
+                        "options": {
+                            "maxiter": 20,
+                            "rhobeg": 0.2
+                        }
+                    }
+                }
+            },
+            "train_kwargs": {
+                "reps": 3,
+                "result": {
+                    "optimized_params": "previous_optimal_point"
+                }
+            },
+            "save_file": "method_7.json"
+        }
+    ],
+    "description": "Recursive Transition States Trainer (p=3)"
+}

--- a/qaoa_training_pipeline/training/__init__.py
+++ b/qaoa_training_pipeline/training/__init__.py
@@ -36,5 +36,5 @@ TRAINERS = {
     "RandomRegularDepthOneFit": RandomRegularDepthOneFit,
     "RecursionTrainer": RecursionTrainer,
     "FixedAngleConjecture": FixedAngleConjecture,
-    "RecursiveTransitionStates": RecursiveTransitionStates
+    "RecursiveTransitionStates": RecursiveTransitionStates,
 }

--- a/qaoa_training_pipeline/training/__init__.py
+++ b/qaoa_training_pipeline/training/__init__.py
@@ -22,6 +22,7 @@ from .reweighting import ReweightingTrainer
 from .scipy_trainer import ScipyTrainer
 from .tqa_trainer import TQATrainer
 from .transition_states import TransitionStatesTrainer
+from .recursive_transition_states import RecursiveTransitionStates
 
 
 TRAINERS = {
@@ -35,4 +36,5 @@ TRAINERS = {
     "RandomRegularDepthOneFit": RandomRegularDepthOneFit,
     "RecursionTrainer": RecursionTrainer,
     "FixedAngleConjecture": FixedAngleConjecture,
+    "RecursiveTransitionStates": RecursiveTransitionStates
 }

--- a/qaoa_training_pipeline/training/param_result.py
+++ b/qaoa_training_pipeline/training/param_result.py
@@ -47,7 +47,7 @@ class ParamResult:
             "system": platform.system(),
             "processor": platform.processor(),
             "platform": platform.platform(),
-            "qaoa_training_pipeline_version": 9,
+            "qaoa_training_pipeline_version": 10,
         }
 
         # Convert, e.g., np.float to float

--- a/qaoa_training_pipeline/training/recursive_transition_states.py
+++ b/qaoa_training_pipeline/training/recursive_transition_states.py
@@ -81,8 +81,8 @@ class RecursiveTransitionStates(BaseTrainer):
             result = ts_trainer.train(cost_op, ts_state, mixer, initial_state, ansatz_circuit)
             ts_state = result["optimized_params"]
             energy = result["energy"]
-            self._all_results[current_reps] = result.data
             current_reps = len(ts_state) // 2
+            self._all_results[current_reps] = result.data
 
         param_result = ParamResult(ts_state, time() - start, self, energy)
         param_result.update(self._all_results)
@@ -142,3 +142,4 @@ class RecursiveTransitionStates(BaseTrainer):
         axis.legend()
 
         return fig, axis
+

--- a/qaoa_training_pipeline/training/recursive_transition_states.py
+++ b/qaoa_training_pipeline/training/recursive_transition_states.py
@@ -39,7 +39,7 @@ class RecursiveTransitionStates(BaseTrainer):
         """Return True if the energy is minimized."""
         return self._trainer.minimization
 
-    # pylint: disable=arguments-differ, pylint: disable=too-many-positional-arguments
+    # pylint: disable=arguments-differ, too-many-positional-arguments, too-many-arguments
     def train(
         self,
         cost_op: SparsePauliOp,
@@ -142,4 +142,5 @@ class RecursiveTransitionStates(BaseTrainer):
         axis.legend()
 
         return fig, axis
+
 

--- a/qaoa_training_pipeline/training/recursive_transition_states.py
+++ b/qaoa_training_pipeline/training/recursive_transition_states.py
@@ -64,7 +64,7 @@ class RecursiveTransitionStates(BaseTrainer):
                 circuit.
 
         Returns:
-            A `ParamResults` with optimization results.
+            A `ParamResult` with optimization results.
         """
         start = time()
         current_reps = len(previous_optimal_point) // 2
@@ -142,5 +142,6 @@ class RecursiveTransitionStates(BaseTrainer):
         axis.legend()
 
         return fig, axis
+
 
 

--- a/qaoa_training_pipeline/training/recursive_transition_states.py
+++ b/qaoa_training_pipeline/training/recursive_transition_states.py
@@ -17,15 +17,14 @@ from qaoa_training_pipeline.training.param_result import ParamResult
 
 class RecursiveTransitionStates(BaseTrainer):
     """Recursively train QAOA by constructing transition states.
-    
-    This class uses an initial set of parameters for depth `p` QAOA to construct transition states 
-    at depth `p+1`, from which the optimized parameters are used to construct the transition 
+
+    This class uses an initial set of parameters for depth `p` QAOA to construct transition states
+    at depth `p+1`, from which the optimized parameters are used to construct the transition
     states at the next depth `p+2`. This process continues until the specified depth is reached.
     """
 
-
-    def __init__(self, trainer: ScipyTrainer): 
-         """Initialize a recursion trainer.
+    def __init__(self, trainer: ScipyTrainer):
+        """Initialize a recursion trainer.
 
         Args:
             trainer: The trainer must be the ScipyTrainer.
@@ -52,15 +51,15 @@ class RecursiveTransitionStates(BaseTrainer):
     ) -> ParamResult:
         """
         Args:
-            cost_op: The cost operator of the problem we want to solve.
-            previous_optimal_point: A local minima in beta and gamma from which to start 
+            cost_op: The cost operator :math:`H_C` of the problem we want to solve.
+            previous_optimal_point: A local minima in beta and gamma from which to start
                 the transition states recursion.
             reps: The number of QAOA layers we want to reach.
             mixer: A quantum circuit representing the mixer of QAOA. This allows us to
                 accommodate, e.g., warm-start QAOA. If this is None, then we assume the
                 standard QAOA mixer.
-            initial_state: A quantum circuit that represents the initial state. If None is
-                given, then we default to the equal superposition state |+>.
+            initial_state: A quantum circuit the represents the initial state. If None is
+                given then we default to the equal superposition state |+>.
             ansatz_circuit: The ansatz circuit in case it differs from the standard QAOA
                 circuit.
 
@@ -71,6 +70,11 @@ class RecursiveTransitionStates(BaseTrainer):
         current_reps = len(previous_optimal_point) // 2
         ts_state = previous_optimal_point
         self._all_results, energy = dict(), None
+
+        if current_reps >= reps:
+            raise ValueError(
+                f"Current reps {current_reps} cannot be greater or equal than desired reps {reps}. "
+            )
 
         while current_reps < reps:
             ts_trainer = TransitionStatesTrainer(self._trainer)
@@ -138,4 +142,3 @@ class RecursiveTransitionStates(BaseTrainer):
         axis.legend()
 
         return fig, axis
-

--- a/qaoa_training_pipeline/training/recursive_transition_states.py
+++ b/qaoa_training_pipeline/training/recursive_transition_states.py
@@ -142,4 +142,3 @@ class RecursiveTransitionStates(BaseTrainer):
         axis.legend()
 
         return fig, axis
-

--- a/qaoa_training_pipeline/training/recursive_transition_states.py
+++ b/qaoa_training_pipeline/training/recursive_transition_states.py
@@ -1,0 +1,128 @@
+
+"""Recursive transition states trainer."""
+
+from time import time
+from typing import Dict, Optional
+import matplotlib.pyplot as plt
+
+
+from qiskit import QuantumCircuit
+from qiskit.quantum_info import SparsePauliOp
+
+from qaoa_training_pipeline.exceptions import TrainingError
+from qaoa_training_pipeline.training.base_trainer import BaseTrainer
+from qaoa_training_pipeline.training.scipy_trainer import ScipyTrainer
+from qaoa_training_pipeline.training.transition_states import TransitionStatesTrainer
+from qaoa_training_pipeline.training.param_result import ParamResult
+
+
+
+class RecursiveTransitionStates(BaseTrainer):
+
+    def __init__(self, trainer: BaseTrainer):  # Here the trainer would be e.g. a SciPy trainers
+        super().__init__(trainer.evaluator)
+
+        self._trainer = trainer
+        self._all_results = None
+
+    @property
+    def minimization(self) -> bool:
+        """Return True if the energy is minimized."""
+        return self._trainer.minimization
+
+    def train(
+        self,
+        cost_op: SparsePauliOp,
+        previous_optimal_point: list[float],
+        reps: int,
+        mixer: Optional[QuantumCircuit] = None,
+        initial_state: Optional[QuantumCircuit] = None,
+        ansatz_circuit: Optional[QuantumCircuit] = None,
+        ) -> ParamResult:
+        """
+        Args:
+            cost_op: The cost operator :math:`H_C` of the problem we want to solve.
+            previous_optimal_point: A local minima in beta and gamma from which to start the transition states recursion.
+            reps: The number of QAOA layers we want to reach. 
+            mixer: A quantum circuit representing the mixer of QAOA. This allows us to
+                accommodate, e.g., warm-start QAOA. If this is None, then we assume the
+                standard QAOA mixer.
+            initial_state: A quantum circuit the represents the initial state. If None is
+                given then we default to the equal superposition state |+>.
+            ansatz_circuit: The ansatz circuit in case it differs from the standard QAOA
+                circuit given by :math:`\exp(-i\gamma H_C)`.
+
+        Returns:
+            A dictionary with optimization results.
+        """
+        start = time()
+        current_reps = len(previous_optimal_point) // 2
+        ts_state = previous_optimal_point
+        self._all_results, energy = dict(), None
+
+        while current_reps < reps:
+            ts_trainer = TransitionStatesTrainer(self._trainer)
+            result = ts_trainer.train(cost_op, ts_state, mixer, initial_state, ansatz_circuit)
+            ts_state = result["optimized_params"]
+            energy = result["energy"]
+            self._all_results[current_reps] = result.data
+            current_reps = len(ts_state) // 2
+        
+        param_result = ParamResult(ts_state, time() - start, self, energy)
+        param_result.update(self._all_results)
+
+        return param_result
+
+    @classmethod
+    def from_config(cls, config: Dict) -> "RecursiveTransitionStates":
+        """Create the trainer from a config file."""
+
+        if config["trainer"] != "ScipyTrainer":
+            raise TrainingError(
+                f"{cls.__name__} only uses ScipyTrainer as trainer. Received " + config["trainer"]
+            )
+
+        trainer = ScipyTrainer.from_config(config["trainer_init"])
+
+        return cls(trainer)
+
+    def to_config(self) -> Dict:
+        """Return the configuration of the trainer."""
+        return {
+            "trainer_name": self.__class__.__name__,
+            "evaluator": self._evaluator.to_config(),
+            "trainer": self._trainer.to_config(),
+        }
+
+    def parse_train_kwargs(self, args_str: Optional[str] = None) -> dict:
+        """Parse a string into the training kwargs."""
+        train_kwargs = dict()
+        for key, val in self.extract_train_kwargs(args_str).items():
+            if key == "reps":
+                train_kwargs[key] = int(val)
+            elif key == "previous_optimal_point":
+                train_kwargs[key] = self.extract_list(val, dtype=float)
+            else:
+                raise ValueError("Unknown key in provided train_kwargs.")
+
+        return train_kwargs
+
+    def plot(
+        self,
+        axis: Optional[plt.Axes] = None,
+        fig: Optional[plt.Figure] = None,
+        **plot_args,
+    ):
+        """Plot the energy progression throughout the recursion."""
+        if axis is None or fig is None:
+            fig, axis = plt.subplots(1, 1)
+
+        rts_idx = sorted(self._all_results.keys())
+        energies = [self._all_results[key]["energy"] for key in rts_idx]
+
+        axis.plot(rts_idx, energies, label="Energy", **plot_args)
+        axis.set_xlabel("Recursion level")
+        axis.set_ylabel("Energy")
+        axis.legend()
+
+        return fig, axis

--- a/qaoa_training_pipeline/training/recursive_transition_states.py
+++ b/qaoa_training_pipeline/training/recursive_transition_states.py
@@ -1,4 +1,3 @@
-
 """Recursive transition states trainer."""
 
 from time import time
@@ -16,8 +15,14 @@ from qaoa_training_pipeline.training.transition_states import TransitionStatesTr
 from qaoa_training_pipeline.training.param_result import ParamResult
 
 
-
 class RecursiveTransitionStates(BaseTrainer):
+    """Recursively train QAOA by constructing transition states.
+    
+    This class uses an initial set of parameters for depth `p` QAOA to construct transition states 
+    at depth `p+1`, from which the optimized parameters are used to construct the transition 
+    states at the next depth `p+2`. This process continues until the specified depth is reached.
+    """
+
 
     def __init__(self, trainer: BaseTrainer):  # Here the trainer would be e.g. a SciPy trainers
         super().__init__(trainer.evaluator)
@@ -30,6 +35,7 @@ class RecursiveTransitionStates(BaseTrainer):
         """Return True if the energy is minimized."""
         return self._trainer.minimization
 
+    # pylint: disable=arguments-differ, pylint: disable=too-many-positional-arguments
     def train(
         self,
         cost_op: SparsePauliOp,
@@ -38,19 +44,20 @@ class RecursiveTransitionStates(BaseTrainer):
         mixer: Optional[QuantumCircuit] = None,
         initial_state: Optional[QuantumCircuit] = None,
         ansatz_circuit: Optional[QuantumCircuit] = None,
-        ) -> ParamResult:
+    ) -> ParamResult:
         """
         Args:
-            cost_op: The cost operator :math:`H_C` of the problem we want to solve.
-            previous_optimal_point: A local minima in beta and gamma from which to start the transition states recursion.
-            reps: The number of QAOA layers we want to reach. 
+            cost_op: The cost operator of the problem we want to solve.
+            previous_optimal_point: A local minima in beta and gamma from which to start 
+                the transition states recursion.
+            reps: The number of QAOA layers we want to reach.
             mixer: A quantum circuit representing the mixer of QAOA. This allows us to
                 accommodate, e.g., warm-start QAOA. If this is None, then we assume the
                 standard QAOA mixer.
-            initial_state: A quantum circuit the represents the initial state. If None is
-                given then we default to the equal superposition state |+>.
+            initial_state: A quantum circuit that represents the initial state. If None is
+                given, then we default to the equal superposition state |+>.
             ansatz_circuit: The ansatz circuit in case it differs from the standard QAOA
-                circuit given by :math:`\exp(-i\gamma H_C)`.
+                circuit.
 
         Returns:
             A dictionary with optimization results.
@@ -67,7 +74,7 @@ class RecursiveTransitionStates(BaseTrainer):
             energy = result["energy"]
             self._all_results[current_reps] = result.data
             current_reps = len(ts_state) // 2
-        
+
         param_result = ParamResult(ts_state, time() - start, self, energy)
         param_result.update(self._all_results)
 

--- a/qaoa_training_pipeline/training/recursive_transition_states.py
+++ b/qaoa_training_pipeline/training/recursive_transition_states.py
@@ -51,15 +51,15 @@ class RecursiveTransitionStates(BaseTrainer):
     ) -> ParamResult:
         """
         Args:
-            cost_op: The cost operator :math:`H_C` of the problem we want to solve.
+            cost_op: The cost operator of the problem we want to solve.
             previous_optimal_point: A local minima in beta and gamma from which to start
                 the transition states recursion.
             reps: The number of QAOA layers we want to reach.
             mixer: A quantum circuit representing the mixer of QAOA. This allows us to
                 accommodate, e.g., warm-start QAOA. If this is None, then we assume the
                 standard QAOA mixer.
-            initial_state: A quantum circuit the represents the initial state. If None is
-                given then we default to the equal superposition state |+>.
+            initial_state: A quantum circuit that represents the initial state. If None is
+                given, then we default to the equal superposition state |+>.
             ansatz_circuit: The ansatz circuit in case it differs from the standard QAOA
                 circuit.
 
@@ -142,3 +142,4 @@ class RecursiveTransitionStates(BaseTrainer):
         axis.legend()
 
         return fig, axis
+

--- a/qaoa_training_pipeline/training/recursive_transition_states.py
+++ b/qaoa_training_pipeline/training/recursive_transition_states.py
@@ -24,7 +24,12 @@ class RecursiveTransitionStates(BaseTrainer):
     """
 
 
-    def __init__(self, trainer: BaseTrainer):  # Here the trainer would be e.g. a SciPy trainers
+    def __init__(self, trainer: ScipyTrainer): 
+         """Initialize a recursion trainer.
+
+        Args:
+            trainer: The trainer must be the ScipyTrainer.
+        """
         super().__init__(trainer.evaluator)
 
         self._trainer = trainer
@@ -60,7 +65,7 @@ class RecursiveTransitionStates(BaseTrainer):
                 circuit.
 
         Returns:
-            A dictionary with optimization results.
+            A `ParamResults` with optimization results.
         """
         start = time()
         current_reps = len(previous_optimal_point) // 2
@@ -133,3 +138,4 @@ class RecursiveTransitionStates(BaseTrainer):
         axis.legend()
 
         return fig, axis
+

--- a/qaoa_training_pipeline/training/recursive_transition_states.py
+++ b/qaoa_training_pipeline/training/recursive_transition_states.py
@@ -143,5 +143,3 @@ class RecursiveTransitionStates(BaseTrainer):
 
         return fig, axis
 
-
-

--- a/qaoa_training_pipeline/training/transition_states.py
+++ b/qaoa_training_pipeline/training/transition_states.py
@@ -96,7 +96,7 @@ class TransitionStatesTrainer(BaseTrainer):
             res = self._trainer.train(cost_op, ts_state, mixer, initial_state, ansatz_circuit)
             res.update({"ts": ts_state})
 
-            self._all_ts[f"ts{idx}"] = res
+            self._all_ts[f"ts{idx}"] = res.data
 
             if not self.minimization:
                 keep = res["energy"] > result.get("energy", -np.inf)

--- a/test/training/test_rts.py
+++ b/test/training/test_rts.py
@@ -1,0 +1,55 @@
+"""Tests for recursive transition states training."""
+
+from test import TrainingPipelineTestCase
+
+from qiskit.quantum_info import SparsePauliOp
+
+from qaoa_training_pipeline.evaluation.mps_evaluator import MPSEvaluator
+from qaoa_training_pipeline.training.recursive_transition_states import RecursiveTransitionStates
+from qaoa_training_pipeline.training.scipy_trainer import ScipyTrainer
+
+
+class TestRecursion(TrainingPipelineTestCase):
+    """Tests for the recursive transition states trainer."""
+
+    def test_simple(self):
+        """Test a simple recursive training."""
+        cost_op = SparsePauliOp.from_list([("ZIIZ", -1), ("IZIZ", -1), ("IIZZ", -1)])
+
+        scipy_trainer = ScipyTrainer(MPSEvaluator())
+        trainer = RecursiveTransitionStates(scipy_trainer)
+
+        result_pre = scipy_trainer.train(cost_op, params0=[0, 0])
+
+        result = trainer.train(
+            cost_op, previous_optimal_point=result_pre["optimized_params"], reps=3
+        )
+
+        self.assertTrue(result[2]["energy"] < result[3]["energy"])
+        self.assertEqual(len(result["optimized_params"]), 6)
+
+    def test_from_config(self):
+        """Test that we can setup from a config."""
+        config = {
+            "trainer": "ScipyTrainer",
+            "trainer_init": {
+                "evaluator": "MPSEvaluator",
+                "evaluator_init": {
+                    "bond_dim_circuit": 24,
+                    "use_vidal_form": True,
+                    "threshold_circuit": 0.001,
+                },
+                "minimize_args": {"options": {"maxiter": 20, "rhobeg": 0.2}},
+            },
+        }
+
+        trainer = RecursiveTransitionStates.from_config(config)
+        self.assertTrue(isinstance(trainer, RecursiveTransitionStates))
+
+    def test_parse_train_kwargs(self):
+        """Test parsing of training args."""
+        scipy_trainer = ScipyTrainer(MPSEvaluator())
+        trainer = RecursiveTransitionStates(scipy_trainer)
+
+        kwargs = trainer.parse_train_kwargs("reps:8:previous_optimal_point:1/2")
+        self.assertDictEqual(kwargs, {"reps": 8, "previous_optimal_point": [1.0, 2.0]})

--- a/test/training/test_train.py
+++ b/test/training/test_train.py
@@ -145,7 +145,7 @@ class TestTrain(TrainingPipelineTestCase):
             # case, is the only one)
             self.assertIn("schmidt_values", result[0].keys())
 
-    @data(0, 1, 2, 3, 4, 5, 6)
+    @data(0, 1, 2, 3, 4, 5, 6, 7)
     def test_methods(self, method_idx: int):
         """Test that the different methods run without input args."""
 
@@ -158,6 +158,7 @@ class TestTrain(TrainingPipelineTestCase):
             4: (0, 2),
             5: (0, 2),
             6: (1, 6),
+            7: (1, 6),
         }
 
         file_name = "dmp_file_test_methods_" + str(method_idx)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.

-->

### Summary
This PR adds a trainer that recursively constructs transition states and uses the SciPy trainer.


### Details and comments
An example method file for the recursive transition states trainer is added as `train_method_7.JSON`.  Changes were also made to `qaoa_training_pipeline/training/__init__.py` and `qaoa_training_pipeline/training/transition_states.py` to accommodate the trainer and ensure that the results can be properly displayed in a JSON file.


### Version updated

Please increment the `qaoa_training_pipeline_version` variable and extend the main README.md. 

- [ ]
