### PR TITLE
Pauli propagation missing methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,9 @@ This repository is still in development: new functionality is being added and th
 |       8 | Improve train tests                    |          #22 |
 |       9 | Add SAT map pre-processing             |          #19 |
 |      10 | Add recursive transition states trainer|          #20 |
-|      11 | Bug fix in train pre-processing data   |          #24 |   
+|      11 | Bug fix in train pre-processing data   |          #24 |
+|      12 | More data in result saving in train.py |          #26 |
+|      13 | Create PPEvaluator from configs        |          #25 |
 
 ## IBM Public Repository Disclosure
 

--- a/qaoa_training_pipeline/evaluation/__init__.py
+++ b/qaoa_training_pipeline/evaluation/__init__.py
@@ -11,6 +11,7 @@
 from .efficient_depth_one import EfficientDepthOneEvaluator
 from .light_cone import LightConeEvaluator
 from .mps_evaluator import MPSEvaluator
+from .pauli_propagation import PPEvaluator
 from .statevector_evaluator import StatevectorEvaluator
 
 
@@ -19,4 +20,5 @@ EVALUATORS = {
     "LightConeEvaluator": LightConeEvaluator,
     "MPSEvaluator": MPSEvaluator,
     "StatevectorEvaluator": StatevectorEvaluator,
+    "PauliPropagationEvaluator": PPEvaluator,
 }

--- a/qaoa_training_pipeline/evaluation/pauli_propagation.py
+++ b/qaoa_training_pipeline/evaluation/pauli_propagation.py
@@ -246,4 +246,4 @@ class PPEvaluator(BaseEvaluator):
                 f"Malformed keyword arguments {init_kwargs}: should be k1:v1:k2:v2_...."
             )
 
-        return {items[idx]: float(items[idx + 1]) for idx in range(0, len(items), 2)}
+        return {"pp_kwargs": {items[idx]: float(items[idx + 1]) for idx in range(0, len(items), 2)}}

--- a/qaoa_training_pipeline/evaluation/pauli_propagation.py
+++ b/qaoa_training_pipeline/evaluation/pauli_propagation.py
@@ -235,8 +235,15 @@ class PPEvaluator(BaseEvaluator):
     # pylint: disable=unused-argument
     def parse_init_kwargs(cls, init_kwargs: Optional[str] = None) -> dict:
         """A hook that sub-classes can implement to parse initialization kwargs."""
-        warnings.warn(
-            "parse_init_kwargs is not yet implemented. "
-            "TODO This will be fixed in a subsequent PR."
-        )
-        return dict()
+
+        if init_kwargs is None:
+            return dict()
+
+        items = init_kwargs.split(":")
+
+        if len(items) % 2 != 0:
+            raise ValueError(
+                f"Malformed keyword arguments {init_kwargs}: should be k1:v1:k2:v2_...."
+            )
+
+        return {items[idx]: float(items[idx + 1]) for idx in range(0, len(items), 2)}

--- a/qaoa_training_pipeline/evaluation/pauli_propagation.py
+++ b/qaoa_training_pipeline/evaluation/pauli_propagation.py
@@ -227,6 +227,11 @@ class PPEvaluator(BaseEvaluator):
         return config
 
     @classmethod
+    def from_config(cls, config: dict) -> "PPEvaluator":
+        """Initialize the Pauli propagation evaluator from a config dictionary."""
+        return cls(**config)
+
+    @classmethod
     # pylint: disable=unused-argument
     def parse_init_kwargs(cls, init_kwargs: Optional[str] = None) -> dict:
         """A hook that sub-classes can implement to parse initialization kwargs."""

--- a/qaoa_training_pipeline/training/param_result.py
+++ b/qaoa_training_pipeline/training/param_result.py
@@ -47,7 +47,7 @@ class ParamResult:
             "system": platform.system(),
             "processor": platform.processor(),
             "platform": platform.platform(),
-            "qaoa_training_pipeline_version": 11,
+            "qaoa_training_pipeline_version": 13,
         }
 
         # Convert, e.g., np.float to float

--- a/test/evaluation/test_paulipropagation.py
+++ b/test/evaluation/test_paulipropagation.py
@@ -52,3 +52,11 @@ class TestPPEvaluator(TestCase):
         trainer = ScipyTrainer(self.evaluator, {"options": {"maxiter": 3, "rhobeg": 0.2}})
         result = trainer.train(cost_op=cost_op, params0=params0)
         self.assertGreaterEqual(len(result["energy_history"]), 3)
+
+    def test_from_config(self):
+        """Test that we can initialize from a config."""
+        init_kwargs = PPEvaluator.parse_init_kwargs("max_weight:4:min_abs_coeff:1e-6")
+        evaluator = PPEvaluator.from_config(init_kwargs)
+
+        self.assertEqual(evaluator.pp_kwargs["max_weight"], 4)
+        self.assertEqual(evaluator.pp_kwargs["min_abs_coeff"], 1e-6)

--- a/test/evaluation/test_paulipropagation.py
+++ b/test/evaluation/test_paulipropagation.py
@@ -59,9 +59,9 @@ class TestPPEvaluator(TestCase):
         evaluator = PPEvaluator.from_config(init_kwargs)
 
         cost_op = SparsePauliOp.from_list([("II", 1.0), ("IZ", 1.0), ("ZZ", 1.0)])
-        result = evaluator.evaluate(cost_op, params=[0.2, 0.3])
+        energy = evaluator.evaluate(cost_op, params=[0.2, 0.3])
 
-        self.assertTrue(isinstance(result["energy"], float))
+        self.assertTrue(isinstance(energy, float))
 
         self.assertEqual(evaluator.pp_kwargs["max_weight"], 4)
         self.assertEqual(evaluator.pp_kwargs["min_abs_coeff"], 1e-6)

--- a/test/evaluation/test_paulipropagation.py
+++ b/test/evaluation/test_paulipropagation.py
@@ -61,7 +61,7 @@ class TestPPEvaluator(TestCase):
         self.assertEqual(evaluator.pp_kwargs["max_weight"], 4)
         self.assertEqual(evaluator.pp_kwargs["min_abs_coeff"], 1e-6)
 
-    def test_from_config(self):
+    def test_from_none_config(self):
         """Test that we can initialize from a config."""
         init_kwargs = PPEvaluator.parse_init_kwargs(None)
         evaluator = PPEvaluator.from_config(init_kwargs)

--- a/test/evaluation/test_paulipropagation.py
+++ b/test/evaluation/test_paulipropagation.py
@@ -60,3 +60,10 @@ class TestPPEvaluator(TestCase):
 
         self.assertEqual(evaluator.pp_kwargs["max_weight"], 4)
         self.assertEqual(evaluator.pp_kwargs["min_abs_coeff"], 1e-6)
+
+    def test_from_config(self):
+        """Test that we can initialize from a config."""
+        init_kwargs = PPEvaluator.parse_init_kwargs(None)
+        evaluator = PPEvaluator.from_config(init_kwargs)
+
+        self.assertTrue(isinstance(evaluator, PPEvaluator))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.

-->

### Summary

Some setup methods are missing from the Pauli propagation.

### Details and comments

This PR adds the method `from_config` to the Pauli propagation evaluator. Also, it implements the init args parsing in the same class. A corresponding test is added.

### Version updated

Please increment the `qaoa_training_pipeline_version` variable and extend the main README.md. 

- [X] Done
