### PR TITLE
Train args saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,8 @@ This repository is still in development: new functionality is being added and th
 |       8 | Improve train tests                    |          #22 |
 |       9 | Add SAT map pre-processing             |          #19 |
 |      10 | Add recursive transition states trainer|          #20 |
-|      11 | Bug fix in train pre-processing data   |          #24 |   
+|      11 | Bug fix in train pre-processing data   |          #24 |
+|      12 | More data in result saving in train.py |          #26 |
 
 ## IBM Public Repository Disclosure
 

--- a/qaoa_training_pipeline/training/param_result.py
+++ b/qaoa_training_pipeline/training/param_result.py
@@ -47,7 +47,7 @@ class ParamResult:
             "system": platform.system(),
             "processor": platform.processor(),
             "platform": platform.platform(),
-            "qaoa_training_pipeline_version": 11,
+            "qaoa_training_pipeline_version": 12,
         }
 
         # Convert, e.g., np.float to float

--- a/test/training/test_train.py
+++ b/test/training/test_train.py
@@ -11,6 +11,7 @@
 from test import TrainingPipelineTestCase
 
 import glob
+import json
 import os
 import sys
 
@@ -58,6 +59,15 @@ class TestTrain(TrainingPipelineTestCase):
                 result["args"]["train_kwargs0"],
                 "num_points:10:parameter_ranges:3/6/3/6",
             )
+
+        # Load from the saved file
+        labels_to_test = ["pre_processing", "cost_operator", "0", "args"]
+        for file_name in glob.glob("*dmp_file*"):
+            with open(file_name, "r") as fin:
+                ld_data = json.load(fin)
+
+                for label in labels_to_test:
+                    self.assertTrue(label in ld_data)
 
     @data("maxcut", "mis:3", "mis")
     def test_problem_classes(self, problem_str: str):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.

-->

### Summary

Train was not saving key data needed in its result.

### Details and comments

This PR adds the `pre_processing`, `cost_operator`, and `args` to the result to be saved. A test is enhanced to check for these fields in the saved data.

### Version updated

Please increment the `qaoa_training_pipeline_version` variable and extend the main README.md. 

- [X] Done
