### PR TITLE
Add custom ansatz op to state vector evaluator

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ This repository is still in development: new functionality is being added and th
 |      11 | Bug fix in train pre-processing data   |          #24 |
 |      12 | More data in result saving in train.py |          #26 |
 |      13 | Create PPEvaluator from configs        |          #25 |
+|      14 | Custom ansatz operator to state vector |          #29 |
 
 ## IBM Public Repository Disclosure
 

--- a/qaoa_training_pipeline/training/param_result.py
+++ b/qaoa_training_pipeline/training/param_result.py
@@ -47,7 +47,7 @@ class ParamResult:
             "system": platform.system(),
             "processor": platform.processor(),
             "platform": platform.platform(),
-            "qaoa_training_pipeline_version": 13,
+            "qaoa_training_pipeline_version": 14,
         }
 
         # Convert, e.g., np.float to float

--- a/test/evaluation/test_statevector.py
+++ b/test/evaluation/test_statevector.py
@@ -53,7 +53,14 @@ class TestStatevectorEvaluator(TestCase):
         """Test that we can construct the ansatz from a different operator."""
         ansatz_op = SparsePauliOp.from_list([("ZI", 1)])
 
-        energy1 = self.evaluator.evaluate(self.cost_op, params=[1.2, 1.3], ansatz_circuit=ansatz_op)
-        energy2 = self.evaluator.evaluate(self.cost_op, params=[1.2, 1.3])
+        angles = [1.2, 1.3]
+
+        energy1 = self.evaluator.evaluate(self.cost_op, params=angles, ansatz_circuit=ansatz_op)
+        energy2 = self.evaluator.evaluate(self.cost_op, params=angles)
 
         self.assertTrue(abs(energy1 - energy2) > 0.1)
+
+        energy1 = self.evaluator.evaluate(self.cost_op, params=angles, ansatz_circuit=self.cost_op)
+        energy2 = self.evaluator.evaluate(self.cost_op, params=angles)
+
+        self.assertAlmostEqual(energy1, energy2, places=6)

--- a/test/evaluation/test_statevector.py
+++ b/test/evaluation/test_statevector.py
@@ -48,3 +48,12 @@ class TestStatevectorEvaluator(TestCase):
         result = trainer.train(cost_op=self.cost_op, params0=[0.2, 0.3])
 
         self.assertGreaterEqual(len(result["energy_history"]), 3)
+
+    def test_custom_ansatz(self):
+        """Test that we can construct the ansatz from a different operator."""
+        ansatz_op = SparsePauliOp.from_list([("ZI", 1)])
+
+        energy1 = self.evaluator.evaluate(self.cost_op, params=[1.2, 1.3], ansatz_circuit=ansatz_op)
+        energy2 = self.evaluator.evaluate(self.cost_op, params=[1.2, 1.3])
+
+        self.assertTrue(abs(energy1 - energy2) > 0.1)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.

-->

### Summary

We can easily add the possibility to use a custom ansatz operator to the state vector evaluator.

### Details and comments

This PR adds the option to give a custom operator to the state vector evaluator and adds a corresponding test.

### Version updated

Please increment the `qaoa_training_pipeline_version` variable and extend the main README.md. 

- [x] Done
