### PR TITLE
Drop py39 and remove caps on qiskit.

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -33,7 +33,7 @@ runs:
         PYTHONWARNINGS: default
       run: |
         # run slow tests only on scheduled event or if input flag is set
-        if [ "${{ inputs.os }}" == "ubuntu-latest" ] && [ "${{ inputs.python-version }}" == "3.9" ]; then
+        if [ "${{ inputs.os }}" == "ubuntu-latest" ] && [ "${{ inputs.python-version }}" == "3.10" ]; then
           export PYTHON="coverage3 run --source qaoa_training_pipeline --parallel-mode"
         fi
         stestr --test-path test run 2> >(tee /dev/stderr out.txt > /dev/null)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9]
+        python-version: [3.10]
     steps:
       - name: Print Concurrency Group
         env:
@@ -75,14 +75,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9, 3.12]
+        python-version: [3.10, 3.12]
         include:
           - os: macos-latest
-            python-version: 3.9
+            python-version: 3.10
           - os: macos-latest
             python-version: 3.12
           - os: windows-latest
-            python-version: 3.9
+            python-version: 3.10
           - os: windows-latest
             python-version: 3.12
     steps:
@@ -118,7 +118,7 @@ jobs:
           mkdir ./ci-artifact-data
           coverage3 combine
           mv .coverage ./ci-artifact-data/pipeline.dat
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == 3.9 }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == 3.10 }}
         shell: bash
       - uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ This repository is still in development: new functionality is being added and th
 |      12 | More data in result saving in train.py |          #26 |
 |      13 | Create PPEvaluator from configs        |          #25 |
 |      14 | Custom ansatz operator to state vector |          #29 |
+|      15 | Remove python 3.9 support              |          #31 |
 
 ## IBM Public Repository Disclosure
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,10 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 100
-target-version = ['py39', 'py310', 'py311', 'py312', 'py313']
+target-version = ['py310', 'py311', 'py312', 'py313']
 
 [tool.pylint.main]
-py-version = "3.9"  # update it when bumping minimum supported python version
+py-version = "3.12"  # update it when bumping minimum supported python version
 
 [tool.pylint.basic]
 good-names = ["a", "b", "i", "j", "k", "d", "n", "m", "ex", "v", "w", "x", "y", "z", "Run", "_", "logger", "q", "c", "r", "qr", "cr", "qc", "nd", "pi", "op", "b", "ar", "br", "p", "cp", "ax", "dt", "__unittest", "iSwapGate", "mu"]

--- a/qaoa_training_pipeline/training/param_result.py
+++ b/qaoa_training_pipeline/training/param_result.py
@@ -47,7 +47,7 @@ class ParamResult:
             "system": platform.system(),
             "processor": platform.processor(),
             "platform": platform.platform(),
-            "qaoa_training_pipeline_version": 14,
+            "qaoa_training_pipeline_version": 15,
         }
 
         # Convert, e.g., np.float to float

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-coverage>=4.4.0,<7.0
 black[jupyter]~=24.1
 pylint>=2.15.0
 ddt>=1.2.0,!=1.4.0,!=1.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ scipy
 quimb>=1.8.2
 matplotlib>=3.3
 python-sat
-qiskit>=1.0,<2.0
+qiskit
 qiskit-optimization[cplex]

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,6 @@ setuptools.setup(
     ),
     install_requires=REQUIREMENTS,
     include_package_data=True,
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     zip_safe=False,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 # Sets this min.version because of differences with env_tmp_dir env.
 minversion = 4.0.2
-envlist = py38, py39, py310, py311, py312, lint
+envlist = py310, py311, py312, lint
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.

-->

### Summary

Python 3.9 is reaching end of life. This PR drops python 3.9 and also removes the caps on Qiskit so that we can run with qiskit 2.0.

### Details and comments

See the changes in the files.

### Version updated

Please increment the `qaoa_training_pipeline_version` variable and extend the main README.md. 

- [x] Done
