### PR TITLE
Enable GPU for SV via passing "GPU" on init_kwargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ This repository is still in development: new functionality is being added and th
 |      22 | SV simulation moved to Qiskit Aer. GPU Support for SV        |          #44 |
 |      23 | Improve transparency of transfer trainer                     |          #45 |
 |      24 | Adding linear ramp parameter support in train.py             |          #46 |
+|      25 | Enable GPU on SV simulation via init_kwargs "GPU"            |          #47 |
 
 ## IBM Public Repository Disclosure
 

--- a/qaoa_training_pipeline/evaluation/statevector_evaluator.py
+++ b/qaoa_training_pipeline/evaluation/statevector_evaluator.py
@@ -22,14 +22,20 @@ class StatevectorEvaluator(AerEvaluator):
     when working with small-scale problem instances.
     """
 
-    def __init__(self, statevector_init_args: Optional[Dict] = None) -> None:
+    def __init__(
+        self, statevector_init_args: Optional[Dict] = None, device: Optional[str] = None
+    ) -> None:
         """Initialize the statevector evaluator.
 
         Args:
             statevector_init_args: The arguments to initialize the StatevectorSimulator with.
                                    Can include "device": "GPU" for GPU acceleration.
+            device: The device to use for the simulation. If provided, it overrides the device
+                    in statevector_init_args.
         """
         self._init_args = statevector_init_args or {}
+        if device:
+            self._init_args["device"] = device
 
         device = self._init_args.get("device")
         if device is not None and device != "GPU":
@@ -49,6 +55,27 @@ class StatevectorEvaluator(AerEvaluator):
         )
 
         super().__init__(estimator=estimator)
+
+    @classmethod
+    def parse_init_kwargs(cls, init_kwargs: Optional[str] = None) -> dict:
+        """Parse initialization kwargs.
+
+        If you are using the GPU, the input string should be "GPU".
+        Any other string will be ignored.
+
+        Args:
+            init_kwargs: The initialization arguments as a string.
+
+        Returns:
+            dict: The parsed initialization arguments.
+        """
+        if init_kwargs is None:
+            return dict()
+
+        if init_kwargs.upper() == "GPU":
+            return {"device": "GPU"}
+
+        return {}
 
     def to_config(self) -> dict:
         config = super().to_config()

--- a/qaoa_training_pipeline/training/param_result.py
+++ b/qaoa_training_pipeline/training/param_result.py
@@ -47,7 +47,7 @@ class ParamResult:
             "system": platform.system(),
             "processor": platform.processor(),
             "platform": platform.platform(),
-            "qaoa_training_pipeline_version": 24,
+            "qaoa_training_pipeline_version": 25,
         }
 
         # Convert, e.g., np.float to float


### PR DESCRIPTION
### Summary

You can now run SV on GPU via adding  --evaluator_init_kwargs GPU on the 'python -m train' command. 

### Details and comments

Backward compatible with pull request #44 

### Version updated

✅
