### PR TITLE
Allow Pauli propagation to accept circuit ansatz

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ This repository is still in development: new functionality is being added and th
 |      30 | Convert a graph with partial assignment to a hamiltonian     |          #53 | 
 |      31 | Refactor linear angle interpolation (increase QAOA depth)    |          #55 |
 |      32 | Standardize the inheritance of evaluators and trainers       |          #57 |
+|      33 | Allow Pauli propagation to accept a custom circuit ansatz    |          #60 |
 
 ## IBM Public Repository Disclosure
 

--- a/qaoa_training_pipeline/evaluation/pauli_propagation.py
+++ b/qaoa_training_pipeline/evaluation/pauli_propagation.py
@@ -139,13 +139,16 @@ class PPEvaluator(BaseEvaluator):
     ) -> float:
         """Evaluate the QAOA circuit parameters."""
 
-        if ansatz_circuit is not None:
-            raise NotImplementedError(
-                f"Custom Ansatz circuits are currently not supported in {self.__class__.__name__}."
-            )
+        if ansatz_circuit is None:
+            ansatz_circuit = cost_op
+        else:
+            if not isinstance(ansatz_circuit, SparsePauliOp):
+                raise NotImplementedError(
+                    "Only ansatz_circuit specified by a sparse Pauli operator is supported."
+                )
 
         circuit = qaoa_ansatz(
-            cost_op,
+            ansatz_circuit,
             reps=len(params) // 2,
             initial_state=initial_state,
             mixer_operator=mixer,  # type: ignore

--- a/qaoa_training_pipeline/training/param_result.py
+++ b/qaoa_training_pipeline/training/param_result.py
@@ -46,7 +46,7 @@ class ParamResult:
             "system": platform.system(),
             "processor": platform.processor(),
             "platform": platform.platform(),
-            "qaoa_training_pipeline_version": 32,
+            "qaoa_training_pipeline_version": 33,
         }
 
         # Convert, e.g., np.float to float

--- a/test/evaluation/test_paulipropagation.py
+++ b/test/evaluation/test_paulipropagation.py
@@ -9,9 +9,15 @@
 """Statevector-based QAOA evaluator tests."""
 
 from unittest import TestCase
+import numpy as np
 
+from qiskit import transpile, QuantumCircuit
+from qiskit.circuit import Parameter
+from qiskit.circuit.library import qaoa_ansatz
 from qiskit.quantum_info import SparsePauliOp
 from ddt import data, ddt, unpack
+
+from qiskit_aer import Aer
 
 from qaoa_training_pipeline.evaluation.statevector_evaluator import StatevectorEvaluator
 from qaoa_training_pipeline.evaluation.pauli_propagation import PPEvaluator
@@ -35,6 +41,29 @@ class TestPPEvaluator(TestCase):
         pp_kwargs = dict(max_weight=9, min_abs_coeff=1e-5)
         self.evaluator = PPEvaluator(pp_kwargs)
         self.sv_evaluator = StatevectorEvaluator()
+        self.simulator = Aer.get_backend("aer_simulator_statevector")
+
+    def qiskit_circuit_simulation(self, cost_op, beta, gamma, circ_op=None):
+        """This is the baseline simulation based on Qiskit."""
+        circ_op = circ_op or cost_op
+
+        depth_one_qaoa = qaoa_ansatz(
+            circ_op,
+            reps=1,
+        ).decompose()
+
+        # Printing parameters gives [ParameterVectorElement(β[0]), ParameterVectorElement(γ[0])]
+        depth_one_qaoa.assign_parameters([beta, gamma], inplace=True)
+        depth_one_qaoa = transpile(depth_one_qaoa, basis_gates=["cx", "sx", "x", "rz"])
+        depth_one_qaoa.save_statevector()
+
+        res = self.simulator.run(depth_one_qaoa).result()
+        state = res.get_statevector()
+
+        cost_mat = np.diag(cost_op.to_matrix())
+
+        nqubits = cost_op.num_qubits
+        return np.real(sum(state[i].conj() * cost_mat[i] * state[i] for i in range(2**nqubits)))
 
     @data(*TEST_CASES)
     @unpack
@@ -72,3 +101,22 @@ class TestPPEvaluator(TestCase):
         evaluator = PPEvaluator.from_config(init_kwargs)
 
         self.assertTrue(isinstance(evaluator, PPEvaluator))
+
+    @data((1, 1), (0.1234, -0.56), (0.25, 0.5), (0.5, 0.25))
+    @unpack
+    def test_sparse_ansatz(self, beta, gamma):
+        """Test the case where the ansatz structure does not match the graph."""
+
+        cost_op = SparsePauliOp.from_list([("IIZZ", 1.0), ("ZZII", 1.0), ("ZIIZ", 1.0)])
+        circ_op = SparsePauliOp.from_list([("IIZZ", 1.0), ("ZZII", 1.0)])
+
+        baseline = self.qiskit_circuit_simulation(cost_op, beta, gamma, circ_op)
+
+        energy = self.evaluator.evaluate(cost_op, [beta, gamma], ansatz_circuit=circ_op)
+        energy2 = self.evaluator.evaluate(cost_op, [beta, gamma])
+
+        # Ensure circuit simulation and efficient depth-one match.
+        self.assertAlmostEqual(energy, baseline, places=6)
+
+        # Ensure efficient depth-one gives different results if the circuit structure is omitted.
+        self.assertTrue(abs(energy2 - energy) > 0.02)

--- a/test/evaluation/test_paulipropagation.py
+++ b/test/evaluation/test_paulipropagation.py
@@ -11,8 +11,7 @@
 from unittest import TestCase
 import numpy as np
 
-from qiskit import transpile, QuantumCircuit
-from qiskit.circuit import Parameter
+from qiskit import transpile
 from qiskit.circuit.library import qaoa_ansatz
 from qiskit.quantum_info import SparsePauliOp
 from ddt import data, ddt, unpack


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.

-->

### Summary

This PR allows the Pauli propagation to work with a custom ansatz given as a SparsePauliOp.

### Details and comments

The ansatz is currently only supported as a SparsePauliOp. QuantumCircuit support will be implemented in another PR.

### Version updated

Please increment the `qaoa_training_pipeline_version` variable and extend the main README.md. 

- [x]
