### PR TITLE
Fix: missing initial_state argument in ScipyTrainer evaluate call

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ This repository is still in development: new functionality is being added and th
 |      31 | Refactor linear angle interpolation (increase QAOA depth)    |          #55 |
 |      32 | Standardize the inheritance of evaluators and trainers       |          #57 |
 |      33 | Allow Pauli propagation to accept a custom circuit ansatz    |          #60 |
+|      34 | ScipyTrainer uses a custom initial_state.                    |          #62 |
+
 
 ## IBM Public Repository Disclosure
 

--- a/qaoa_training_pipeline/training/param_result.py
+++ b/qaoa_training_pipeline/training/param_result.py
@@ -46,7 +46,7 @@ class ParamResult:
             "system": platform.system(),
             "processor": platform.processor(),
             "platform": platform.platform(),
-            "qaoa_training_pipeline_version": 33,
+            "qaoa_training_pipeline_version": 34,
         }
 
         # Convert, e.g., np.float to float

--- a/qaoa_training_pipeline/training/scipy_trainer.py
+++ b/qaoa_training_pipeline/training/scipy_trainer.py
@@ -111,6 +111,7 @@ class ScipyTrainer(BaseTrainer, HistoryMixin):
                 params=qaoa_angles,
                 mixer=mixer,
                 ansatz_circuit=ansatz_circuit,
+                initial_state=initial_state,
             )
 
             energy = float(energy)


### PR DESCRIPTION
### Summary
Add `initial_state` argument in the `evaluate` in the `ScipyTrainer` class.

### Details and comments
The initial_state is not explicitly passed to the `evaluate` function, making not suitable for warm-start. 

@eggerdj 