### PR TITLE
Fix missing information on the k-th qubit when computing correlators 

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ This repository is still in development: new functionality is being added and th
 |      32 | Standardize the inheritance of evaluators and trainers       |          #57 |
 |      33 | Allow Pauli propagation to accept a custom circuit ansatz    |          #60 |
 |      34 | ScipyTrainer uses a custom initial_state.                    |          #62 |
-|      35 | Bug fix - Initial state used in computing correlates.        |          #63 |
+|      35 | Bug fix - Initial state used in computing correlates.        |          #64 |
 
 ## IBM Public Repository Disclosure
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ This repository is still in development: new functionality is being added and th
 |      32 | Standardize the inheritance of evaluators and trainers       |          #57 |
 |      33 | Allow Pauli propagation to accept a custom circuit ansatz    |          #60 |
 |      34 | ScipyTrainer uses a custom initial_state.                    |          #62 |
-
+|      35 | Bug fix - Initial state used in computing correlates.        |          #63 |
 
 ## IBM Public Repository Disclosure
 

--- a/qaoa_training_pipeline/evaluation/efficient_depth_one.py
+++ b/qaoa_training_pipeline/evaluation/efficient_depth_one.py
@@ -208,8 +208,11 @@ class EfficientDepthOneEvaluator(BaseEvaluator):
             phase_i = np.exp(-1.0j * 4 * gamma * circuit_graph[idx, k])
 
             u1 = np.diag([1.0, phase_i])
-
-            rho_i = 0.5 * rho_i + 0.5 * np.dot(u1, np.dot(rho_i, u1.conj().T))
+            # info of the qubit k
+            qk = self._initial_states[k]
+            # coefficient of the |1> state
+            ck = np.abs(qk[1]) ** 2
+            rho_i = (1 - ck) * rho_i + ck * np.dot(u1, np.dot(rho_i, u1.conj().T))
 
         # Apply the mixer operator
         assert self._mixers, "_mixers must be defined before calling single_z()"
@@ -292,7 +295,12 @@ class EfficientDepthOneEvaluator(BaseEvaluator):
             phase_j = np.exp(-1.0j * 4 * gamma * circuit_graph[idx2, k])
             u1 = np.diag([1.0, phase_j, phase_i, phase_i * phase_j])
 
-            rho_ij = 0.5 * rho_ij + 0.5 * np.dot(u1, np.dot(rho_ij, u1.conj().T))
+            # info of the qubit k
+            qk = self._initial_states[k]
+            # coefficient of the |1> state
+            ck = np.abs(qk[1]) ** 2
+
+            rho_ij = (1 - ck) * rho_ij + ck * np.dot(u1, np.dot(rho_ij, u1.conj().T))
 
         # Apply the two-qubit Rzz gate between `i` and `j`
         if circuit_graph[idx1, idx2] != 0.0:

--- a/qaoa_training_pipeline/training/param_result.py
+++ b/qaoa_training_pipeline/training/param_result.py
@@ -46,7 +46,7 @@ class ParamResult:
             "system": platform.system(),
             "processor": platform.processor(),
             "platform": platform.platform(),
-            "qaoa_training_pipeline_version": 34,
+            "qaoa_training_pipeline_version": 35,
         }
 
         # Convert, e.g., np.float to float

--- a/test/evaluation/test_efficient_depth_one.py
+++ b/test/evaluation/test_efficient_depth_one.py
@@ -17,7 +17,7 @@ from qiskit import transpile, QuantumCircuit
 from qiskit.circuit import Parameter
 from qiskit.circuit.library import qaoa_ansatz, PauliEvolutionGate
 from qiskit.primitives import StatevectorEstimator
-from qiskit.quantum_info import SparsePauliOp, Pauli, Operator
+from qiskit.quantum_info import SparsePauliOp, Pauli, Operator, Statevector
 
 from qiskit_aer import Aer
 
@@ -252,3 +252,89 @@ class TestEfficientDepthOne(TrainingPipelineTestCase):
 
         # Prepares the |0001> state which has energy 3/2.
         self.assertAlmostEqual(energy, 1.5)
+
+    def test_warm_start(self):
+        """
+        Test the efficient depth-one with a custom initial state and standard mixer.
+        """
+        cost_op = SparsePauliOp.from_list(
+            [
+                ("ZII", -1),
+                ("IZI", +0.81),
+                ("IIZ", -0.43),
+                ("ZZI", -1.5),
+                ("ZIZ", +0.21),
+                ("IZZ", -0.11),
+            ]
+        )
+        params = [0.41, 0.34]
+        init = QuantumCircuit(3)
+        for j in range(3):
+            theta = 0.1 * (j + 1)
+            init.ry(theta, j)
+
+        # Build the full QAOA circuit to get the reference statevector
+        qc = QuantumCircuit(3)
+        qc.compose(init, inplace=True)
+
+        # Cost unitary: exp(-i gamma * cost_op)
+        cost_gate = PauliEvolutionGate(cost_op, time=params[1])
+        qc.append(cost_gate, range(3))
+
+        # Mixer unitary: exp(-i beta * sum_j X_j)  ≡  Rx(2*beta) on each qubit
+        for j in range(3):
+            qc.rx(2 * params[0], j)
+
+        # Compute <psi | cost_op | psi> via statevector simulation
+        sv = Statevector(qc)
+        expected_energy = sv.expectation_value(cost_op).real
+
+        energy = self.evaluator.evaluate(cost_op, params, initial_state=init)
+        self.assertAlmostEqual(float(energy), expected_energy)
+
+    def test_warm_start_aligned_driver(self):
+        """
+        Test the efficient depth-one with a custom initial state and mixer.
+        """
+        cost_op = SparsePauliOp.from_list(
+            [
+                ("ZII", -1),
+                ("IZI", +0.81),
+                ("IIZ", -0.43),
+                ("ZZI", -1.5),
+                ("ZIZ", +0.21),
+                ("IZZ", -0.11),
+            ]
+        )
+        params = [0.41, 0.34]
+        init = QuantumCircuit(3)
+        for j in range(3):
+            theta = 0.1 * (j + 1)
+            init.ry(theta, j)
+
+        # Build the full QAOA circuit to get the reference statevector
+        qc = QuantumCircuit(3)
+        qc.compose(init, inplace=True)
+
+        # Cost unitary: exp(-i gamma * cost_op)
+        cost_gate = PauliEvolutionGate(cost_op, time=params[1])
+        qc.append(cost_gate, range(3))
+
+        # Mixer so that the initial state is the ground state
+        mixer = QuantumCircuit(3)
+        beta = Parameter("Beta")
+
+        for j in range(3):
+            theta = 0.1 * (j + 1)
+            mixer.ry(theta, j)
+            mixer.rz(-2 * beta, j)
+            mixer.ry(-theta, j)
+
+        qc.compose(mixer.assign_parameters({beta: params[0]}), inplace=True)
+
+        # Compute <psi | cost_op | psi> via statevector simulation
+        sv = Statevector(qc)
+        expected_energy = sv.expectation_value(cost_op).real
+
+        energy = self.evaluator.evaluate(cost_op, params, initial_state=init, mixer=mixer)
+        self.assertAlmostEqual(float(energy), expected_energy)


### PR DESCRIPTION
**Summary**
Fixing computation of correlators in EfficientDepthOneEvaluator for arbitrary initial product states.

**Details and comments**
Currently, the information of the surrounding qubits (i.e. the k-th one) in computing cost function is missing (assumed to be |+> state always). This led to unphysical results for, e.g., warm start.

The fix is based on Algorithm 1 on page 13 of [paper](https://arxiv.org/pdf/2009.10095)

Note: it is a copy of PR https://github.com/qiskit-community/qaoa_training_pipeline/pull/61 , but due to inconsistencies in git I had to do a new PR.

@eggerdj 