### PR TITLE
Add custom __repr__ to ParamResult

### DIFF
--- a/qaoa_training_pipeline/framework/param_result.py
+++ b/qaoa_training_pipeline/framework/param_result.py
@@ -78,6 +78,17 @@ class ParamResult:
     def __len__(self):
         return len(self.data)
 
+    def __repr__(self):
+        out = f"{self.__class__.__name__} with {self.data.keys()} entries.\n"
+
+        out += f"Obtained from training with {self.data['trainer']['trainer_name']}"
+        out += f" in {self.data['train_duration']} seconds \n"
+        out += "optimized_params:" + str(self.data["optimized_params"]) + "\n"
+        out += "optimized_qaoa_angles:" + str(self.data["optimized_qaoa_angles"]) + "\n"
+        out += "energy:" + str(self.data["energy"])
+
+        return out
+
     def keys(self):
         """Return the keys of the underlying dict"""
         return self.data.keys()


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.

-->

### Summary
Add `__repr__` to `ParamResult` so that results from training are printed in a controllable way.


### Details and comments
Currently, when users produce a `ParamResult` and print its content, all the information contained in the class is printed, including large energy and parameter histories. This PR adds the `__repr__` method to the class, allowing to print in a controllable way.


### Version updated

Please increment the `qaoa_training_pipeline_version` variable and extend the main README.md. 

- [ ]
